### PR TITLE
Use 16x16 sized tiles.

### DIFF
--- a/Mole Game - Brackeys Game Jam 2024/Assets/Scripts/Mole Game.cs
+++ b/Mole Game - Brackeys Game Jam 2024/Assets/Scripts/Mole Game.cs
@@ -41,7 +41,8 @@ public class MoleGame : MonoBehaviour
                 GameObject go = new GameObject("Tile Sprite");
                 tileSprites[i,j] = go;
                 
-                go.transform.position = new Vector3(i-32, j-32, 0);
+                go.transform.localScale = new Vector2(0.5f, 0.5f);
+                go.transform.position = new Vector3((i-32) / 2.0f, (j-32) / 2.0f, 0);
                 
                 SpriteRenderer renderer = go.AddComponent<SpriteRenderer>();
                 Texture2D texture = Resources.Load<Texture2D>("blank_square");


### PR DESCRIPTION
It's still just colored squares, but now I think they might be 16x16 pixels! (The blank_square texture is 32x32 pixels, then scaled by 1/2 and 1/2, so 16x16 pixels and the position is halved as well to make the grid tight again without spacing) :)

![image](https://github.com/user-attachments/assets/60632914-27a3-455b-a020-87e8577ba59f)
